### PR TITLE
Change crafting furniture 'get items' hotkey to g

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5245,7 +5245,7 @@ void iexamine::workbench_internal( player &p, const tripoint &examp,
     amenu.addentry( start_long_craft, true,            '3', _( "Craft as long as possible" ) );
     amenu.addentry( work_on_craft,    !crafts.empty(), '4', _( "Work on craft" ) );
     if( !part ) {
-        amenu.addentry( get_items,    items_at_loc,    '5', _( "Get items" ) );
+        amenu.addentry( get_items,    items_at_loc,    'g', _( "Get items" ) );
     }
 
     amenu.query();


### PR DESCRIPTION
#### Summary
```SUMMARY: Interface "Change crafting furniture 'get items' hotkey to g, consistent with taking items from inside vehicles."```

#### Purpose of change
Annoys me less, enhances consistency and allows players to utilize existing muscle memory.

#### Describe the solution
Changed the 5 hotkey to g.

#### Describe alternatives you've considered
Investigating if you can have two hotkeys, so it can be 5 and g.

#### Additional context
@anothersimulacrum on discord made this really easy, cheers :blush: 